### PR TITLE
Change how the message is rendered

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -63,10 +63,10 @@ def score(command, delta, message, icon_emoji):
 
 
 def plusplus(command):
-  score(command, 1, u'{to}++ (now at {score}){reason}', ':thumbsup:')
+  score(command, 1, u'/++ {to} (now at {score}){reason}', ':thumbsup:')
 
 def minusminus(command):
-  score(command, -1, u'{to}-- (now at {score}){reason}', ':thumbsdown:')
+  score(command, -1, u'/-- {to} (now at {score}){reason}', ':thumbsdown:')
 
 def do_paste(command, content, filetype='text'):
   api.files_upload(

--- a/commands.py
+++ b/commands.py
@@ -63,10 +63,10 @@ def score(command, delta, message, icon_emoji):
 
 
 def plusplus(command):
-  score(command, 1, u'/++ {to} (now at {score}){reason}', ':thumbsup:')
+  score(command, 1, u'/++ {to} {reason} (now at {score})', ':thumbsup:')
 
 def minusminus(command):
-  score(command, -1, u'/-- {to} (now at {score}){reason}', ':thumbsdown:')
+  score(command, -1, u'/-- {to} {reason} (now at {score})', ':thumbsdown:')
 
 def do_paste(command, content, filetype='text'):
   api.files_upload(


### PR DESCRIPTION
Change the rendered message from

```
foo++
```

to

```
/++ foo
```

So that new hires can easily see the syntax when existing employees plusplus people.